### PR TITLE
Changes for 2017 fall cycle of revisions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,12 @@ version: 2
 jobs:
    build:
      docker:
-       - image: koppor/texlive
+       - image: ubuntu:16.04
      steps:
        - checkout
-       - run: apt-get update && apt-get install -y latex2html
+       - run: apt-get update && apt-get install -y latex2html make git wget tidy
        - run: make ALLOW_FETCH=1
+       - run: mkdir artifacts && cp *.pdf *.html artifacts/
+
+       - store_artifacts:
+           path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: koppor/texlive
+     steps:
+       - checkout
+       - run: apt-get update && apt-get install -y latex2html
+       - run: make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ jobs:
      steps:
        - checkout
        - run: apt-get update && apt-get install -y latex2html make git wget tidy
-       - run: make ALLOW_FETCH=1
-       - run: mkdir artifacts && cp *.pdf *.html artifacts/
+       - run: make ALLOW_FETCH=1 all web.tar
+       - run: mkdir artifacts && cp *.pdf *.html web.tar artifacts/
 
        - store_artifacts:
            path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,4 @@ jobs:
      steps:
        - checkout
        - run: apt-get update && apt-get install -y latex2html
-       - run: make
+       - run: make ALLOW_FETCH=1

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ local/lib/tex/macros:
 endif
 
 %.dvi : %.tex
-	$(LATEX_ENV) $(LATEX) $<
-	$(LATEX_ENV) $(LATEX) $<
+	$(LATEX_ENV) $(LATEX) -halt-on-error $<
+	$(LATEX_ENV) $(LATEX) -halt-on-error $<
 
 # dvips version 5.86e and 5.92b fail to write a %%CreationDate
 %.ps : %.dvi

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ local/lib/tex/macros:
 	@exit 1
 endif
 
+%.old-$(HASH).tex:
+	git show $(HASH):$*.tex > policies.old-$(HASH).tex
+
+%.diff-$(HASH).tex: %.old-$(HASH).tex %.tex
+	latexdiff "$<" "$*.tex" > "$*.diff-$(HASH).tex"
+
 %.dvi : %.tex
 	$(LATEX_ENV) $(LATEX) -halt-on-error $<
 	$(LATEX_ENV) $(LATEX) -halt-on-error $<

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ ifeq ($(ALLOW_FETCH),1)
 local/bin/ts-html-convert:
 	mkdir -p local/bin/
 	wget https://tech-squares.scripts.mit.edu/ts-html-convert --output-document="$@"
+	#sed --in-place -e 's#/usr/athena/bin/perl#/usr/bin/perl#' "$@"
 	chmod +x "$@"
 
 local/lib/tex/macros:

--- a/constit.tex
+++ b/constit.tex
@@ -13,6 +13,7 @@ Amended 13 August 2002
 Amended 23 April 2013
 Amended 3 September 2013
 Rewritten 28 April 2015
+Amended 29 November 2016
 \end{history}
 
 

--- a/policies.tex
+++ b/policies.tex
@@ -48,7 +48,7 @@
 \duty To be elected, a candidate must receive approval from at least a one-half vote.  
 \subsection{}Candidates must accept their nomination to run. Candidates should be present for the election meeting if possible but are not required to be. Candidates are encouraged to make themselves available to answer questions if they cannot attend in person.
 \subsection{}Candidates present for the election may vote by written ballot once the club has completed asking all questions, and their votes shall be tallied with the rest of the votes.
-\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions. 
+\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Members-at-Large cannot be on the EC already in another capacity. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.
 
 \subarticle{Appointments}
 

--- a/policies.tex
+++ b/policies.tex
@@ -1,6 +1,6 @@
 \documentclass{bylaws}
 \title{Tech Squares Standing Policies}
-\date{25 October 2016}
+\date{27 February 2018}
 
 \newcommand{\sptimes}[2]{\emph{Adopted #1. To be reviewed #2.}}
 \renewcommand{\thesection}{Standing Policy \arabic{section}}

--- a/policies.tex
+++ b/policies.tex
@@ -21,12 +21,12 @@
 
 
 \policy{Club Level}
-\sptimes{Spring 2015}{Fall 2017}
+\sptimes{Spring 2015}{Fall 2020}
 \section{}The club level shall be the \textsc{Callerlab} Plus program.
 
 
 \policy{Membership}
-\sptimes{Spring 2015}{Fall 2017}
+\sptimes{Spring 2015}{Fall 2020}
 
 \section{}At its discretion, the Executive Committee may grant membership to prospective members who have not gone through the class. Such prospective members must dance club level proficiently and have attended at least four of fifteen consecutive weekly dances.
 \section{}Club membership does not expire, though a club member may relinquish membership.
@@ -34,7 +34,7 @@
 
 \policy{Elections and Appointments}
 \label{pol:electappoint}
-\sptimes{Spring 2015}{Fall 2017}
+\sptimes{Spring 2015}{Fall 2020}
 
 \subarticle{Elections}
 \label{pol:elect}
@@ -58,7 +58,7 @@
 
 
 \policy{Meetings}
-\sptimes{Spring 2015}{Fall 2017}
+\sptimes{Spring 2015}{Fall 2020}
 
 \subarticle{Executive Committee}
 
@@ -75,7 +75,7 @@
 
 
 \policy{Class}
-\sptimes{Spring 2015}{Fall 2017}
+\sptimes{Spring 2015}{Fall 2020}
 \section{}The class shall be open to anyone, except that the EC may, at its discretion and for up to one class per year, limit the class to MIT students only.
 \section{}The Class Coordinator, after notifying the EC, may remove people from the class if they are interfering with the class or preventing other class members from learning.
 \section{}The EC must approve the list of class graduates. The Class Coordinator shall provide the EC with a list of class members, and provide a recommendation of which should graduate, which should not, and which deserve discussion.

--- a/policies.tex
+++ b/policies.tex
@@ -48,7 +48,7 @@
 \duty To be elected, a candidate must receive approval from at least a one-half vote.  
 \subsection{}Candidates must accept their nomination to run. Candidates should be present for the election meeting if possible but are not required to be. Candidates are encouraged to make themselves available to answer questions if they cannot attend in person.
 \subsection{}Candidates present for the election may vote by written ballot once the club has completed asking all questions, and their votes shall be tallied with the rest of the votes.
-\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Members-at-Large cannot be on the EC already in another capacity. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.
+\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Member-at-Large candidates cannot already be on the EC they are being elected to in another capacity. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.
 
 \subarticle{Appointments}
 

--- a/policies.tex
+++ b/policies.tex
@@ -39,13 +39,13 @@
 \subarticle{Elections}
 \label{pol:elect}
 
-\subsection{}The elected positions shall be elected in the order in which the offices are mentioned in Article VII, Section 2 of the constitution. 
-\subsection{}Approval voting shall be used. 
+\subsection{}The elected positions shall be elected in the order in which the offices are mentioned in Article VII, Section 2 of the constitution.
+\subsection{}Approval voting shall be used.
 \subsection{}For each position,
 \duty Each candidate shall have a chance to state a platform and answer questions.
 \duty The club shall have an opportunity to discuss in private, including for uncontested positions.
 \duty The club may ask individual candidates questions in private.
-\duty To be elected, a candidate must receive approval from at least a one-half vote.  
+\duty To be elected, a candidate must receive approval from at least a one-half vote.
 \subsection{}Candidates must accept their nomination to run. Candidates should be present for the election meeting if possible but are not required to be. Candidates are encouraged to make themselves available to answer questions if they cannot attend in person.
 \subsection{}Candidates present for the election may vote by written ballot once the club has completed asking all questions, and their votes shall be tallied with the rest of the votes.
 \subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.

--- a/policies.tex
+++ b/policies.tex
@@ -52,7 +52,7 @@
 
 \subarticle{Appointments}
 
-\subsection{}At any time, the Executive Committee may appoint additional officers, including but not limited to those required by the constitution or standing policies.
+\subsection{}At any time, the Executive Committee may appoint additional, non-EC officers, including but not limited to any required by the constitution or standing policies.
 \subsection{}The EC shall solicit suggestions from the club for each appointed position at least once each year, around the beginning of their term.
 \subsection{}Within a month of taking office, the incoming EC shall select and install a slate of appointed officers. The EC is encouraged to select their appointed officers before taking office, so that the EC and appointed officers can take office simultaneously.
 

--- a/policies.tex
+++ b/policies.tex
@@ -65,7 +65,7 @@
 \subsection{}Executive Committee members shall attend Executive Committee meetings.
 \subsection{}Executive Committee meetings shall be announced to the Executive Committee members at least 24 hours in advance.
 \subsection{}Meetings shall be open to the club except when sensitive or confidential information will be discussed. Open meetings shall be announced to the club in advance.
-\subsection{}Quorum shall be a majority of the EC.
+\subsection{}Quorum shall be more than half of the EC.
 
 \subarticle{Club Meetings}
 \subsection{}Club members must be present to vote. Voting proxies and written absentee ballots are not allowed at club meetings. However, candidates present for their election may vote by written ballot, as described in \ref{pol:electappoint}.

--- a/policies.tex
+++ b/policies.tex
@@ -28,8 +28,8 @@
 \policy{Membership}
 \sptimes{Spring 2015}{Fall 2020}
 
-\section{}At its discretion, the Executive Committee may grant membership to prospective members who have not gone through the class. Such prospective members must dance club level proficiently and have attended at least four of fifteen consecutive weekly dances.
-\section{}Club membership does not expire, though a club member may relinquish membership.
+\section{}At its discretion, the Executive Committee may grant membership to prospective members outside the class process. Such prospective members must dance club level proficiently and have attended at least four of fifteen consecutive weekly dances.
+\section{}Club membership does not expire, though a club member may relinquish membership, and membership may be revoked per \ref{pol:safer}.
 
 
 \policy{Elections and Appointments}
@@ -158,6 +158,7 @@
 \duty \textbf{Saturday dance coordinator}: ensuring the smooth functioning of Saturday dances and that all Saturday dance jobs are handled
 
 \policy{Safer Dances}
+\label{pol:safer}
 \sptimes{Summer 2016}{Fall 2018}
 
 \section{} The \href{safer-dances.html}{Safer Dances Policy} and associated \href{safer-dances-procedures.html}{procedures} are standing policies of Tech Squares and incorporated by reference.

--- a/policies.tex
+++ b/policies.tex
@@ -75,6 +75,7 @@
 
 
 \policy{Class}
+\label{pol:class}
 \sptimes{Spring 2015}{Fall 2020}
 \section{}The class shall be open to anyone, except that the EC may, at its discretion and for up to one class per year, limit the class to MIT students only.
 \section{}The Class Coordinator, after notifying the EC, may remove people from the class if they are interfering with the class or preventing other class members from learning.
@@ -111,6 +112,7 @@
 \duty take attendance of class members
 \duty maintain lists of calls and definitions taught in the class
 \duty run class meetings
+\duty prepare recommended lists of graduates, as detailed in \ref{pol:class}, and ensure the EC votes on them
 \duty order club badges for new graduates and other club members
 \duty add new graduates to the club roster and mailing lists
 \duty organize graduation

--- a/policies.tex
+++ b/policies.tex
@@ -65,7 +65,7 @@
 \subsection{}Executive Committee members shall attend Executive Committee meetings.
 \subsection{}Executive Committee meetings shall be announced to the Executive Committee members at least 24 hours in advance.
 \subsection{}Meetings shall be open to the club except when sensitive or confidential information will be discussed. Open meetings shall be announced to the club in advance.
-\subsection{}Quorum shall be more than half of the EC.
+\subsection{}Quorum shall be a majority of the EC.
 
 \subarticle{Club Meetings}
 \subsection{}Club members must be present to vote. Voting proxies and written absentee ballots are not allowed at club meetings. However, candidates present for their election may vote by written ballot, as described in \ref{pol:electappoint}.

--- a/policies.tex
+++ b/policies.tex
@@ -52,9 +52,9 @@
 
 \subarticle{Appointments}
 
-\subsection{}The Executive Committee may appoint additional officers, including but not limited to those required by the constitution or standing policies.
+\subsection{}At any time, the Executive Committee may appoint additional officers, including but not limited to those required by the constitution or standing policies.
 \subsection{}The EC shall solicit suggestions from the club for each appointed position at least once each year, around the beginning of their term.
-\subsection{}Within a month of taking office, the incoming EC shall select and install appointed officers. The EC is encouraged to select their appointed officers before taking office, so that the EC and appointed officers can take office simultaneously.
+\subsection{}Within a month of taking office, the incoming EC shall select and install a slate of appointed officers. The EC is encouraged to select their appointed officers before taking office, so that the EC and appointed officers can take office simultaneously.
 
 
 \policy{Meetings}

--- a/policies.tex
+++ b/policies.tex
@@ -48,7 +48,8 @@
 \duty To be elected, a candidate must receive approval from at least a one-half vote.  
 \subsection{}Candidates must accept their nomination to run. Candidates should be present for the election meeting if possible but are not required to be. Candidates are encouraged to make themselves available to answer questions if they cannot attend in person.
 \subsection{}Candidates present for the election may vote by written ballot once the club has completed asking all questions, and their votes shall be tallied with the rest of the votes.
-\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Member-at-Large candidates cannot already be on the EC they are being elected to in another capacity. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.
+\subsection{}After electing all other candidates, Members-at-Large will be elected to fill out the EC. Some Members-at-Large may need to be students. All student-only Member-at-Large positions will be elected simultaneously first, followed by all remaining Member-at-Large positions.
+\subsection{}Members-at-large may not simultaneously hold other EC positions.
 
 \subarticle{Appointments}
 


### PR DESCRIPTION
PDFs: [diff](https://github.com/tech-squares/govdocs/files/1714157/policies.diff.pdf) [new](https://github.com/tech-squares/govdocs/files/1714158/policies.pdf)

Changes:
* Require that members-at-large cannot otherwise be on the EC (partial fix for Govdocs-#14)
* Note class grad lists in duties section too (Govdocs-#13)
* Clarify that the EC can member people regardless of class status; previously, somebody who took the class, failed it, and learned to dance elsewhere would not be eligible to be membered without going through the class, which seems non-ideal. (Govdocs-#15)
* Make explicit that membership can be revoked
* Clarify that officers can be appointed at any time (Govdocs-#18)
* Update safer dances coordinator and add another instance of the e-mail address.
* Bump standing policy review dates
* Update constitution modification time

